### PR TITLE
Implement a bi-directional Dijkstra option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `route_calc()` can now accept a route as a GeoJSON in addition to a DataFrame.
 * Extracted geojson-to-DataFrame parsing in `load_route()` into a shared `route_geojson_to_df()` helper, reused by both the json and gpx.
 * Performance benchmark tests (`tests/regression_tests/test_benchmarks.py`) for `compute_routes()` and `compute_smoothed_routes()`, run via `make benchmark`.
+* `bidirectional_dijkstra` route config option, enabling a bidirectional Dijkstra search (simultaneous forward search from the source and backward search from each destination, meeting in the middle) to reduce route calculation time for large/complex meshes. See [docs/config/route_planning.md](docs/config/route_planning.md) for details.
+
 
 ## [1.1.11] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-* Performance benchmark tests (`tests/regression_tests/test_benchmarks.py`) for `compute_routes()` and `compute_smoothed_routes()`, run via `make benchmark`.
+* `bidirectional_dijkstra` route config option, enabling a bidirectional Dijkstra search (simultaneous forward search from the source and backward search from each destination, meeting in the middle) to reduce route calculation time for large/complex meshes. See [docs/config/route_planning.md](docs/config/route_planning.md) for details.
+
 
 ## [1.1.11] - 2026-07-02
 

--- a/docs/config/route_planning.md
+++ b/docs/config/route_planning.md
@@ -30,6 +30,8 @@ above is the minimal set of configuration parameters necessary to run the route 
   "zero_currents": false,
   "fixed_speed": false,
   "waypoint_splitting": false,
+  "early_stopping_criterion": true,
+  "bidirectional_dijkstra": false,
   "smoothing_max_iterations": 2000,
   "smoothing_blocked_sic": 10.0,
   "smoothing_merge_separation": 1e-3,
@@ -44,6 +46,8 @@ above is the full set of configuration parameters that can be used for route pla
 * `zero_currents` *(bool)* : For development use only. Removes the effect of currents acting on the ship, setting all current vectors to zero.
 * `fixed_speed` *(bool)*  : For development use only. Removes the effect of variable speed acting on the ship, ship speed set to max speed defined in the vessel config.
 * `waypoint_splitting` *(bool)* : Used to enable or disable splitting around the input waypoints. If enabled, all cells containing waypoints will be split to the maximum split depth given in the mesh config.
+* `early_stopping_criterion` *(bool)* : Used to enable or disable stopping the Dijkstra search as soon as all destination waypoints are reached, rather than continuing until the whole mesh has been visited. Defaults to `true`.
+* `bidirectional_dijkstra` *(bool)* : Used to enable a bidirectional Dijkstra search, which searches simultaneously forwards from the source and backwards from each destination, meeting in the middle. This can reduce route calculation time, particularly for large or complex meshes. Produces the same overall route cost as the standard (unidirectional) search; where a mesh has multiple equally-optimal paths, the two searches may settle on different (but equal-cost) routes. Has no effect if `early_stopping_criterion` is `false`. Defaults to `false`.
 * `smoothing_max_iterations` *(int)* : For development use only. Maximum number of iterations in the path smoothing. For most paths convergence is met 100x earlier than this value.
 * `smoothing_blocked_metric` *(string)*: For development use only. The environmental or performance variable to be used for blocking in the smoothing algorithm.
 * `smoothing_blocked_percentage` *(float)* : For development use only. The maximum difference in the blocking variable allowed before a cell is blocked for the smoothing.

--- a/polar_route/config_validation/route_schema.py
+++ b/polar_route/config_validation/route_schema.py
@@ -19,6 +19,8 @@ route_schema = {
         "adjust_waypoints":{"type": "boolean"},
         "zero_currents": {"type": "boolean"},
         "fixed_speed": {"type": "boolean"},
+        "early_stopping_criterion": {"type": "boolean"},
+        "bidirectional_dijkstra": {"type": "boolean"},
         "smoothing_blocked_sic": {"type": "number"},
         "smoothing_max_iterations": {"type": "integer"},
         "smoothing_merge_separation": {"type": "number"},

--- a/polar_route/route_planner/route_planner.py
+++ b/polar_route/route_planner/route_planner.py
@@ -288,6 +288,10 @@ class RoutePlanner:
         if "early_stopping_criterion" not in self.config:
             self.config["early_stopping_criterion"] = True
 
+        # Bidirectional Dijkstra not specified then define as false (opt-in optimisation)
+        if "bidirectional_dijkstra" not in self.config:
+            self.config["bidirectional_dijkstra"] = False
+
         # Required nodes to visit
         self._required_nodes = []
 
@@ -354,6 +358,11 @@ class RoutePlanner:
         self.routes_smoothed = []
         self.neighbour_legs = {}
         self.direction = [1, 2, 3, 4, -1, -2, -3, -4]
+
+        # Cache of backward searches (one per destination cellbox id) used by
+        # `_bidirectional_dijkstra`. Reused/expanded across multiple source waypoints since a
+        # backward search from a fixed destination doesn't depend on the source waypoint.
+        self._backward_wps = {}
 
     def _splitting_around_waypoints(self, waypoints_df):
         """
@@ -655,6 +664,188 @@ class RoutePlanner:
                 consider_neighbours(wp, min_obj_indx)
                 wp.visit(min_obj_indx)
 
+    def _bidirectional_search(self, wp, e_wp):
+        """
+        Runs a bidirectional variant of Dijkstra searching forward from the source
+        waypoint `wp` and backward from the end waypoint `e_wp` simultaneously, meeting in the
+        middle.
+
+        Args:
+            wp (SourceWaypoint): object contains the lat, long information of the source waypoint
+            e_wp (Waypoint): the end waypoint to search towards
+
+        Returns:
+            best_cost (float): the cost of the shortest path from `wp` to `e_wp`, or `np.inf` if
+                no route exists
+            best_node (str or None): the cellbox index at which the forward and backward
+                searches meet on the shortest path, or `None` if no route exists
+            bwd_wp (SourceWaypoint): the backward search object rooted at `e_wp`, needed by
+                `_splice_meeting_path` to reconstruct the route
+        """
+        obj = self.config["objective_function"]
+
+        key = e_wp.get_cellbox_indx()
+        if key not in self._backward_wps:
+            self._backward_wps[key] = SourceWaypoint(e_wp, [])
+        bwd_wp = self._backward_wps[key]
+
+        def find_min_objective(source_wp):
+            """
+            Finds the index and cost of the unvisited cell in the source waypoint's routing
+            table with the minimum cost for the given objective function
+            """
+            min_obj = np.inf
+            cellbox_indx = -1
+            for node_id in source_wp.routing_table.keys():
+                if not source_wp.is_visited(node_id):
+                    node_obj = source_wp.get_obj(node_id, obj)
+                    if node_obj < min_obj:
+                        min_obj = node_obj
+                        cellbox_indx = str(node_id)
+            return cellbox_indx, min_obj
+
+        best_meeting = [np.inf, None]  # [cost, node] - mutated by the closures below
+
+        def consider_neighbours(_id):
+            """
+            Relaxes the forward neighbours of the newly-settled cell at `_id`. Also checks
+            whether any of these edges cross into the (already settled) backward frontier,
+            which would represent a valid candidate meeting point.
+            """
+            neighbour_map = self.env_mesh.neighbour_graph.get_neighbour_map(_id)
+            for case, neighbours in neighbour_map.items():
+                if neighbours:
+                    for neighbour in neighbours:
+                        nb_id = str(neighbour)
+                        edges = self._neighbour_cost(_id, nb_id, int(case))
+                        edges_cost = sum(
+                            segment.get_variable(obj) for segment in edges
+                        )
+                        new_cost = wp.get_obj(_id, obj) + edges_cost
+                        if new_cost < wp.get_obj(nb_id, obj):
+                            wp.update_routing_table(nb_id, RoutingInfo(_id, edges))
+                        if bwd_wp.is_visited(nb_id):
+                            total = (
+                                wp.get_obj(_id, obj)
+                                + edges_cost
+                                + bwd_wp.get_obj(nb_id, obj)
+                            )
+                            if total < best_meeting[0]:
+                                best_meeting[0] = total
+                                best_meeting[1] = nb_id
+
+        def consider_predecessors(_id):
+            """
+            Relaxes the predecessors of the newly-settled cell at `_id` in the backward search.
+            Since mesh adjacency is symmetric, the geometric neighbours of `_id` are exactly the
+            candidate predecessors X for which an edge X -> _id may exist. The edge cost is
+            computed in the true forward direction (X -> _id) to correctly account for
+            asymmetric edge costs. Also checks whether any of these edges cross into the
+            (already settled) forward frontier, which would represent a valid candidate meeting
+            point.
+            """
+            neighbour_map = self.env_mesh.neighbour_graph.get_neighbour_map(_id)
+            for neighbours in neighbour_map.values():
+                if neighbours:
+                    for neighbour in neighbours:
+                        pred_id = str(neighbour)
+                        case = self.env_mesh.neighbour_graph.get_neighbour_case(
+                            self.cellboxes_lookup[pred_id],
+                            self.cellboxes_lookup[_id],
+                        )
+                        if case == 0:
+                            case = self.env_mesh.neighbour_graph.get_global_mesh_neighbour_case(
+                                self.cellboxes_lookup[pred_id],
+                                self.cellboxes_lookup[_id],
+                            )
+                        if case == 0:
+                            # Not neighbours in the forward direction (can happen at mesh
+                            # boundaries handled differently by the two lookup methods), skip.
+                            continue
+                        edges = self._neighbour_cost(pred_id, _id, int(case))
+                        edges_cost = sum(
+                            segment.get_variable(obj) for segment in edges
+                        )
+                        new_cost = bwd_wp.get_obj(_id, obj) + edges_cost
+                        if new_cost < bwd_wp.get_obj(pred_id, obj):
+                            bwd_wp.update_routing_table(pred_id, RoutingInfo(_id, edges))
+                        if wp.is_visited(pred_id):
+                            total = (
+                                wp.get_obj(pred_id, obj)
+                                + edges_cost
+                                + bwd_wp.get_obj(_id, obj)
+                            )
+                            if total < best_meeting[0]:
+                                best_meeting[0] = total
+                                best_meeting[1] = pred_id
+
+        done = False
+        while not (done and wp.is_all_cells_visited(self._required_nodes)):
+            progressed = False
+
+            # Scan both frontiers once per iteration. These same costs are reused below both
+            # to select which node to expand and (before expanding) to check the standard
+            # bidirectional stopping rule, avoiding a redundant rescan after expansion.
+            fwd_indx, fwd_cost = find_min_objective(wp)
+            bwd_indx, bwd_cost = find_min_objective(bwd_wp) if not done else (-1, np.inf)
+
+            if not done:
+                # Standard bidirectional stopping rule: once the sum of the smallest remaining
+                # unvisited cost in each direction is >= the best meeting cost found so far (or
+                # both frontiers are exhausted), the shortest path is known and cannot be
+                # improved by further expansion in either direction. Costs only increase as
+                # each frontier expands (non-negative edge weights), so it's safe to check this
+                # using the costs already scanned above, before settling either node this
+                # iteration, rather than rescanning again afterwards.
+                if (fwd_cost == np.inf and bwd_cost == np.inf) or (
+                    fwd_cost + bwd_cost >= best_meeting[0]
+                ):
+                    done = True
+
+            # Expand the forward frontier by one node
+            if fwd_indx != -1:
+                progressed = True
+                consider_neighbours(fwd_indx)
+                wp.visit(fwd_indx)
+
+            # Expand the backward frontier by one node
+            if not done and bwd_indx != -1:
+                progressed = True
+                consider_predecessors(bwd_indx)
+                bwd_wp.visit(bwd_indx)
+
+            if not progressed:
+                # Forward and backward frontiers are both exhausted
+                break
+
+        return best_meeting[0], best_meeting[1], bwd_wp
+
+
+    def _splice_meeting_path(self, wp, bwd_wp, meeting_node, destination_key):
+        """
+        Splices the backward path from `meeting_node` to `destination_key` (found by
+        `_bidirectional_search`) into `wp`'s routing table, so `_dijkstra_routes` can trace the
+        route exactly as it would for a purely forward search.
+
+        Note this mutates `wp.routing_table`; since the same `wp` is reused across multiple end
+        waypoints, callers should snapshot and restore `wp.routing_table` around calls to this
+        method to avoid different end waypoints' spliced paths clashing on shared intermediate
+        cellboxes.
+
+        Args:
+            wp (SourceWaypoint): the source waypoint whose routing table should be spliced into
+            bwd_wp (SourceWaypoint): the backward search object rooted at the destination
+            meeting_node (str): the cellbox index at which the forward and backward searches meet
+            destination_key (str): the cellbox index of the destination waypoint
+        """
+        node_indx = meeting_node
+        while node_indx != destination_key:
+            info = bwd_wp.routing_table[node_indx]
+            next_hop = info.node_indx
+            wp.update_routing_table(next_hop, RoutingInfo(node_indx, info.path))
+            node_indx = next_hop
+
+
     def _neighbour_cost(self, node_id, neighbour_id, case):
         """
         Determines the neighbour cost when travelling from the cell at node_id to the cell at neighbour_id given the
@@ -830,12 +1021,39 @@ class RoutePlanner:
 
         logger.info("============= Dijkstra Route Creation ============")
         logger.info(f" - Objective = {self.config['objective_function']}")
-        for wp in src_wps:
-            logger.info("--- Processing Source Waypoint = {}".format(wp.get_name()))
-            self._dijkstra(wp, end_wps)
-
-        # Using Dijkstra graph compute route and meta information to all end_waypoints
-        routes = self._dijkstra_routes(src_wps, end_wps)
+        use_bidirectional = (
+            self.config["bidirectional_dijkstra"]
+            and self.config["early_stopping_criterion"]
+        )
+        if use_bidirectional:
+            routes = []
+            for wp in src_wps:
+                logger.info(
+                    "--- Processing Source Waypoint = {}".format(wp.get_name())
+                )
+                for e_wp in end_wps:
+                    best_cost, best_node, bwd_wp = self._bidirectional_search(
+                        wp, e_wp
+                    )
+                    # Snapshot the routing table so the splice below (which is specific to this
+                    # end waypoint) can be rolled back before moving on to the next end
+                    # waypoint, avoiding different end waypoints' spliced paths clashing on
+                    # shared intermediate cellboxes.
+                    saved_routing_table = dict(wp.routing_table)
+                    if best_node is not None:
+                        self._splice_meeting_path(
+                            wp, bwd_wp, best_node, e_wp.get_cellbox_indx()
+                        )
+                    routes.extend(self._dijkstra_routes([wp], [e_wp]))
+                    wp.routing_table = saved_routing_table
+        else:
+            for wp in src_wps:
+                logger.info(
+                    "--- Processing Source Waypoint = {}".format(wp.get_name())
+                )
+                self._dijkstra(wp, end_wps)
+            # Using Dijkstra graph compute route and meta information to all end_waypoints
+            routes = self._dijkstra_routes(src_wps, end_wps)
         logger.info("Dijkstra routing complete...")
         self.routes_dijkstra = routes
         # Returning the constructed routes

--- a/tests/regression_tests/test_benchmarks.py
+++ b/tests/regression_tests/test_benchmarks.py
@@ -19,10 +19,6 @@ DIJKSTRA_BENCHMARK_FILES = {
     "small": "example_routes/dijkstra/time/twin_otter_tt_route_dijkstra.json",
     "medium": "example_routes/dijkstra/fuel/checkerboard.json",
     "large": "example_routes/dijkstra/fuel/gaussian_random_field.json",
-    # Similar cell count to "large", but with variable ship speed, non-zero currents and
-    # waypoint splitting enabled, better reflecting real-world complex sea ice navigation
-    # (where the current "large" case's uniform zero-current mesh causes near-exhaustive
-    # node visitation and understates bidirectional search's benefit).
     "complex": "example_routes/dijkstra/fuel/gaussian_random_field_waypointsplitting.json",
 }
 

--- a/tests/regression_tests/test_benchmarks.py
+++ b/tests/regression_tests/test_benchmarks.py
@@ -8,6 +8,7 @@ test fixtures, ranging from small to large meshes.
 Run with: `pytest -m benchmark --benchmark-only`
 """
 
+import copy
 import json
 
 import pytest
@@ -18,6 +19,11 @@ DIJKSTRA_BENCHMARK_FILES = {
     "small": "example_routes/dijkstra/time/twin_otter_tt_route_dijkstra.json",
     "medium": "example_routes/dijkstra/fuel/checkerboard.json",
     "large": "example_routes/dijkstra/fuel/gaussian_random_field.json",
+    # Similar cell count to "large", but with variable ship speed, non-zero currents and
+    # waypoint splitting enabled, better reflecting real-world complex sea ice navigation
+    # (where the current "large" case's uniform zero-current mesh causes near-exhaustive
+    # node visitation and understates bidirectional search's benefit).
+    "complex": "example_routes/dijkstra/fuel/gaussian_random_field_waypointsplitting.json",
 }
 
 SMOOTHED_BENCHMARK_FILES = {
@@ -30,6 +36,7 @@ BENCHMARK_ROUNDS = {
     "small": 5,
     "medium": 3,
     "large": 1,
+    "complex": 1,
 }
 
 
@@ -40,12 +47,36 @@ def _load_route(relative_path):
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize(
-    "size", ["small", "medium", "large"], ids=["small", "medium", "large"]
+    "size",
+    ["small", "medium", "large", "complex"],
+    ids=["small", "medium", "large", "complex"],
 )
 def test_benchmark_dijkstra(benchmark, size):
-    """Benchmark `compute_routes()` (Dijkstra) across small/medium/large meshes."""
+    """Benchmark `compute_routes()` (Dijkstra) across small/medium/large/complex meshes."""
     route = _load_route(DIJKSTRA_BENCHMARK_FILES[size])
     config = route["config"]["route_info"]
+
+    benchmark.pedantic(
+        calculate_dijkstra_route,
+        args=(config, route),
+        rounds=BENCHMARK_ROUNDS[size],
+        iterations=1,
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize(
+    "size",
+    ["small", "medium", "large", "complex"],
+    ids=["small", "medium", "large", "complex"],
+)
+def test_benchmark_bidirectional_dijkstra(benchmark, size):
+    """Benchmark `compute_routes()` with `bidirectional_dijkstra` enabled, across
+    small/medium/large/complex meshes, for direct comparison against
+    `test_benchmark_dijkstra`."""
+    route = _load_route(DIJKSTRA_BENCHMARK_FILES[size])
+    config = copy.deepcopy(route["config"]["route_info"])
+    config["bidirectional_dijkstra"] = True
 
     benchmark.pedantic(
         calculate_dijkstra_route,
@@ -71,3 +102,4 @@ def test_benchmark_smoothed(benchmark, size):
         rounds=BENCHMARK_ROUNDS[size],
         iterations=1,
     )
+

--- a/tests/regression_tests/test_bidirectional_dijkstra.py
+++ b/tests/regression_tests/test_bidirectional_dijkstra.py
@@ -1,0 +1,120 @@
+"""
+Verifies that enabling `bidirectional_dijkstra` in the route config produces routes identical to
+the standard (unidirectional) Dijkstra search, for every example dijkstra route test file.
+"""
+import copy
+import json
+
+import numpy as np
+import pytest
+
+from .utils import (
+    get_route_test_files,
+    calculate_dijkstra_route,
+    compare_route_coordinates,
+    compare_waypoint_names,
+    compare_time,
+    compare_fuel,
+    compare_battery,
+    compare_cell_indices,
+    compare_cases,
+)
+
+import logging
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+# Dynamically discover test files
+ALL_TEST_ROUTES = get_route_test_files('dijkstra')
+
+# Meshes that are uniform/symmetric grids with zero currents (the "great_circle" example
+# routes) have many exactly-tied-cost shortest paths between the source and destination.
+# Unidirectional and bidirectional Dijkstra can legitimately settle on different tied paths
+# depending on traversal order, and the waypoint boundary correction applied afterwards is
+# sensitive to exactly which path was chosen, so the resulting routes' coordinates/per-point
+# values can differ even though both are correct shortest routes.
+# Exact route matching isn't a meaningful check for these files;
+# they're instead checked for total-cost equivalence only (see
+# `test_bidirectional_total_cost_matches_unidirectional`).
+TIED_PATH_ROUTES = [f for f in ALL_TEST_ROUTES if 'great_circle' in f]
+TEST_ROUTES = [f for f in ALL_TEST_ROUTES if f not in TIED_PATH_ROUTES]
+
+
+def _compute_route_pair(route_file):
+    """
+    Computes routes both with the standard (unidirectional) Dijkstra search and with
+    `bidirectional_dijkstra` enabled, from the same input mesh/config, so the two can be
+    compared directly.
+    """
+    LOGGER.info(f'Test File: {route_file}')
+
+    with open(route_file, 'r') as fp:
+        reference_route = json.load(fp)
+
+    base_config = reference_route['config']['route_info']
+
+    unidirectional_config = copy.deepcopy(base_config)
+    unidirectional_route = calculate_dijkstra_route(
+        unidirectional_config, copy.deepcopy(reference_route)
+    )
+
+    bidirectional_config = copy.deepcopy(base_config)
+    bidirectional_config['bidirectional_dijkstra'] = True
+    bidirectional_route = calculate_dijkstra_route(
+        bidirectional_config, copy.deepcopy(reference_route)
+    )
+
+    return [unidirectional_route, bidirectional_route]
+
+
+@pytest.fixture(scope='session', params=TEST_ROUTES)
+def bidirectional_route_pair(request):
+    return _compute_route_pair(request.param)
+
+
+@pytest.fixture(scope='session', params=TIED_PATH_ROUTES)
+def tied_path_route_pair(request):
+    return _compute_route_pair(request.param)
+
+
+@pytest.mark.parametrize('compare_func', [
+    compare_route_coordinates,
+    compare_waypoint_names,
+    compare_time,
+    compare_cell_indices,
+    compare_cases
+], ids=['coordinates', 'waypoint_names', 'time', 'cell_indices', 'cases'])
+def test_bidirectional_matches_unidirectional(bidirectional_route_pair, compare_func):
+    """Test route property matches between unidirectional and bidirectional search"""
+    compare_func(*bidirectional_route_pair)
+
+
+def test_bidirectional_fuel_battery(bidirectional_route_pair):
+    """Test fuel/battery consumption matches between unidirectional and bidirectional search"""
+    path_variables = bidirectional_route_pair[0]['config']['route_info']['path_variables']
+    if 'fuel' in path_variables:
+        compare_fuel(*bidirectional_route_pair)
+    if 'battery' in path_variables:
+        compare_battery(*bidirectional_route_pair)
+
+
+def test_bidirectional_total_cost_matches_unidirectional(tied_path_route_pair):
+    """
+    For meshes with many exactly-tied-cost shortest paths (see `TIED_PATH_ROUTES`), only
+    check that bidirectional search finds a route whose total cost is close to
+    unidirectional search's, rather than requiring an identical route. Either algorithm may
+    legitimately settle on a different tied-optimal path, and the waypoint boundary
+    correction applied afterwards is sensitive to exactly which path was chosen, so a small
+    relative difference between the two corrected totals is expected.
+    """
+    unidirectional_route, bidirectional_route = tied_path_route_pair
+    path_variables = unidirectional_route['config']['route_info']['path_variables']
+
+    for property_name in ['traveltime'] + [v for v in path_variables if v != 'traveltime']:
+        values_a = unidirectional_route["paths"]["features"][0]["properties"][property_name]
+        values_b = bidirectional_route["paths"]["features"][0]["properties"][property_name]
+        np.testing.assert_allclose(
+            values_b[-1], values_a[-1], rtol=0.01,
+            err_msg=f'Difference in total "{property_name}"'
+        )
+


### PR DESCRIPTION
Closes #359, also see #280.

Adding `bidirectional_dijkstra` route config option, enabling a bidirectional Dijkstra search (simultaneous forward search from the source and backward search from each destination, meeting in the middle) to attempt to reduce route calculation time for large/complex meshes. 