### PR TITLE
Replacing numpy scalar math with `math` module

### DIFF
--- a/polar_route/route_planner/crossing.py
+++ b/polar_route/route_planner/crossing.py
@@ -5,13 +5,12 @@ In the section below we will go through, stage by stage, how the crossing point 
 used within the class.
 """
 
-import numpy as np
+import math
 import logging
 from polar_route.utils import unit_time, unit_speed
 
 # Module logger
 logger = logging.getLogger(__name__)
-np.seterr(divide="ignore", invalid="ignore")
 
 
 def traveltime_in_cell(xdist, ydist, u, v, s, tt_dist=None):
@@ -29,25 +28,29 @@ def traveltime_in_cell(xdist, ydist, u, v, s, tt_dist=None):
         traveltime (float): the travel time within the cell
         dist (float): the distance within the cell
     """
-    dist = np.sqrt(xdist**2 + ydist**2)
-    cval = np.sqrt(u**2 + v**2)
+    dist = math.sqrt(xdist**2 + ydist**2)
+    cval = math.sqrt(u**2 + v**2)
 
     dotprod = xdist * u + ydist * v
     diffsqrs = s**2 - cval**2
 
     if diffsqrs == 0.0:
         if dotprod == 0.0:
-            traveltime = np.inf
+            traveltime = math.inf
         else:
             if ((dist**2) / (2 * dotprod)) < 0:
-                traveltime = np.inf
+                traveltime = math.inf
             else:
                 traveltime = dist**2 / (2 * dotprod)
     else:
-        traveltime = (np.sqrt(dotprod**2 + (dist**2) * diffsqrs) - dotprod) / diffsqrs
+        sqrt_arg = dotprod**2 + (dist**2) * diffsqrs
+        if sqrt_arg < 0:
+            traveltime = math.nan
+        else:
+            traveltime = (math.sqrt(sqrt_arg) - dotprod) / diffsqrs
 
     if traveltime < 0:
-        traveltime = np.inf
+        traveltime = math.inf
 
     if tt_dist:
         return traveltime, dist
@@ -143,19 +146,19 @@ class NewtonianDistance:
         iteration_num = 0
         while improving:
             F, dF, X1, X2, t1, t2 = f(y0, x, a, Y, u1, v1, u2, v2, s1, s2)
-            if F == np.inf:
-                return np.nan, np.inf
+            if F == math.inf:
+                return math.nan, math.inf
             y0 = y0 - (F / dF)
             improving = abs((F / dF) / (X1 * X2)) > self.optimizer_tol
             iteration_num += 1
             # Assume convergence impossible after 1000 iterations and exit
             if iteration_num > 1000:
                 # Set crossing point to nan and travel times to infinity
-                y0 = np.nan
+                y0 = math.nan
                 t1 = -1
                 t2 = -1
 
-        return y0, unit_time(np.array([t1, t2]), self.unit_time)
+        return y0, (unit_time(t1, self.unit_time), unit_time(t2, self.unit_time))
 
     def _F(self, y, x, a, Y, u1, v1, u2, v2, s1, s2):
         """
@@ -190,15 +193,15 @@ class NewtonianDistance:
         if X1ns < 0:
             X1 = -1
         else:
-            X1 = np.sqrt(X1ns)
+            X1 = math.sqrt(X1ns)
         X2ns = D2**2 + C2 * (a**2 + (Y - y) ** 2)
         if X2ns < 0:
             X2 = -1
         else:
-            X2 = np.sqrt(X2ns)
+            X2 = math.sqrt(X2ns)
 
         if X1 < 0 or X2 < 0:
-            return np.inf, np.inf, np.inf, np.inf, np.inf, np.inf
+            return math.inf, math.inf, math.inf, math.inf, math.inf, math.inf
 
         F = X2 * (y - ((v1 * (X1 - D1)) / C1)) + X1 * (y - Y + ((v2 * (X2 - D2)) / C2))
 
@@ -234,7 +237,7 @@ class NewtonianDistance:
         Returns:
             traveltime (float) - Traveltime between the two points within cell in unit_time
         """
-        x = (Cp[0] - Wp[0]) * self.m_long * np.cos(Wp[1] * (np.pi / 180))
+        x = (Cp[0] - Wp[0]) * self.m_long * math.cos(Wp[1] * (math.pi / 180))
         y = (Cp[1] - Wp[1]) * self.m_lat
         Su = self.source_cellbox.agg_data["uC"]
         Sv = self.source_cellbox.agg_data["vC"]
@@ -276,18 +279,18 @@ class NewtonianDistance:
         Ssp = self.source_speed
         Nsp = self.neighbour_speed
 
-        x = s_dcx * self.m_long * np.cos(s_cy * (np.pi / 180))
-        a = n_dcx * self.m_long * np.cos(n_cy * (np.pi / 180))
+        x = s_dcx * self.m_long * math.cos(s_cy * (math.pi / 180))
+        a = n_dcx * self.m_long * math.cos(n_cy * (math.pi / 180))
         Y = ptvl * (n_cy - s_cy) * self.m_lat
 
         # Optimising to determine the y-value of the crossing point
         y, travel_time = self._newton_optimisation(
             self._F, x, a, Y, Su, Sv, Nu, Nv, Ssp, Nsp
         )
-        if np.isnan(y) or travel_time[0] < 0 or travel_time[1] < 0:
-            travel_time = [np.inf, np.inf]
-            cross_points = [np.nan, np.nan]
-            cell_points = [np.nan, np.nan]
+        if math.isnan(y) or travel_time[0] < 0 or travel_time[1] < 0:
+            travel_time = [math.inf, math.inf]
+            cross_points = [math.nan, math.nan]
+            cell_points = [math.nan, math.nan]
             return travel_time, cross_points, cell_points
 
         cross_points = (s_cx + ptvl * s_dcx, s_cy + ptvl * y / self.m_lat)
@@ -299,10 +302,10 @@ class NewtonianDistance:
         smax = s_cy + s_dcy
         emin = n_cy - n_dcy
         emax = n_cy + n_dcy
-        vmin = np.max([smin, emin])
-        vmax = np.min([smax, emax])
+        vmin = max(smin, emin)
+        vmax = min(smax, emax)
         if (cross_points[1] < vmin) or (cross_points[1] > vmax):
-            cross_points = (cross_points[0], np.clip(cross_points[1], vmin, vmax))
+            cross_points = (cross_points[0], min(max(cross_points[1], vmin), vmax))
 
         return travel_time, cross_points, cell_points
 
@@ -346,20 +349,20 @@ class NewtonianDistance:
             ptvl
             * (n_cx - s_cx)
             * self.m_long
-            * np.cos((n_cy + s_cy) * (np.pi / 180) / 2.0)
+            * math.cos((n_cy + s_cy) * (math.pi / 180) / 2.0)
         )
 
         y, travel_time = self._newton_optimisation(
             self._F, x, a, Y, Su, Sv, Nu, Nv, Ssp, Nsp
         )
-        if np.isnan(y) or travel_time[0] < 0 or travel_time[1] < 0:
-            travel_time = [np.inf, np.inf]
-            cross_points = [np.nan, np.nan]
-            cell_points = [np.nan, np.nan]
+        if math.isnan(y) or travel_time[0] < 0 or travel_time[1] < 0:
+            travel_time = [math.inf, math.inf]
+            cross_points = [math.nan, math.nan]
+            cell_points = [math.nan, math.nan]
             return travel_time, cross_points, cell_points
 
         clon = s_cx + ptvl * y / (
-            self.m_long * np.cos((n_cy + s_cy) * (np.pi / 180) / 2.0)
+            self.m_long * math.cos((n_cy + s_cy) * (math.pi / 180) / 2.0)
         )
         clat = s_cy + -1 * ptvl * s_dcy
 
@@ -372,10 +375,10 @@ class NewtonianDistance:
         smax = s_cx + s_dcx
         emin = n_cx - n_dcx
         emax = n_cx + n_dcx
-        vmin = np.max([smin, emin])
-        vmax = np.min([smax, emax])
+        vmin = max(smin, emin)
+        vmax = min(smax, emax)
         if (cross_points[0] < vmin) or (cross_points[0] > vmax):
-            cross_points = (np.clip(cross_points[0], vmin, vmax), cross_points[1])
+            cross_points = (min(max(cross_points[0], vmin), vmax), cross_points[1])
 
         return travel_time, cross_points, cell_points
 
@@ -414,8 +417,8 @@ class NewtonianDistance:
             ptvX = -1.0
             ptvY = 1.0
 
-        dx1 = ptvX * s_dcx * self.m_long * np.cos(s_cy * (np.pi / 180))
-        dx2 = ptvX * n_dcx * self.m_long * np.cos(n_cy * (np.pi / 180))
+        dx1 = ptvX * s_dcx * self.m_long * math.cos(s_cy * (math.pi / 180))
+        dx2 = ptvX * n_dcx * self.m_long * math.cos(n_cy * (math.pi / 180))
         dy1 = ptvY * s_dcy * self.m_lat
         dy2 = ptvY * n_dcy * self.m_lat
 
@@ -436,12 +439,12 @@ class NewtonianDistance:
         # Determining traveltime
         t1 = traveltime_in_cell(dx1, dy1, Su, Sv, Ssp)
         t2 = traveltime_in_cell(dx2, dy2, Nu, Nv, Nsp)
-        travel_time = unit_time(np.array([t1, t2]), self.unit_time)
+        travel_time = (unit_time(t1, self.unit_time), unit_time(t2, self.unit_time))
 
         if travel_time[0] < 0 or travel_time[1] < 0:
-            travel_time = [np.inf, np.inf]
-            cross_points = [np.nan, np.nan]
-            cell_points = [np.nan, np.nan]
+            travel_time = [math.inf, math.inf]
+            cross_points = [math.nan, math.nan]
+            cell_points = [math.nan, math.nan]
             return travel_time, cross_points, cell_points
 
         return travel_time, cross_points, cell_points
@@ -473,9 +476,9 @@ class NewtonianDistance:
                 )
             )
 
-            travel_time = [np.inf, np.inf]
-            cross_points = [np.nan, np.nan]
-            cell_points = [np.nan, np.nan]
+            travel_time = [math.inf, math.inf]
+            cross_points = [math.nan, math.nan]
+            cell_points = [math.nan, math.nan]
 
         logger.debug(f"NewtonianDistance.value >> TravelTime >> {travel_time}")
         return travel_time, cross_points, cell_points, self.case

--- a/polar_route/route_planner/crossing_smoothing.py
+++ b/polar_route/route_planner/crossing_smoothing.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import pyproj
 import logging
@@ -19,19 +20,21 @@ def dist_around_globe(start_point, crossing_point):
     Returns:
         a (float): longitude distance between the two points in degrees
     """
-    a1 = np.sign(crossing_point - start_point) * (
-        np.max([start_point, crossing_point]) - np.min([start_point, crossing_point])
-    )
-    a2 = -(
-        360
-        - (
-            np.max([start_point, crossing_point])
-            - np.min([start_point, crossing_point])
-        )
-    ) * np.sign(crossing_point - start_point)
+    diff = crossing_point - start_point
+    if diff > 0:
+        sign = 1
+    elif diff < 0:
+        sign = -1
+    else:
+        sign = 0
+
+    span = max(start_point, crossing_point) - min(start_point, crossing_point)
+
+    a1 = sign * span
+    a2 = -(360 - span) * sign
 
     dist = [a1, a2]
-    indx = np.argmin(abs(np.array(dist)))
+    indx = 0 if abs(dist[0]) <= abs(dist[1]) else 1
 
     a = dist[indx]
     return a
@@ -54,18 +57,18 @@ def rhumb_line_distance(start_waypoint, end_waypoint):
     x_e, y_e = end_waypoint
 
     r = 6371.1 * 1000.0
-    dy_corrected = np.log(
-        np.tan((np.pi / 4) + (y_e * (np.pi / 180)) / 2)
-        / np.tan((np.pi / 4) + (y_s * (np.pi / 180)) / 2)
+    dy_corrected = math.log(
+        math.tan((math.pi / 4) + (y_e * (math.pi / 180)) / 2)
+        / math.tan((math.pi / 4) + (y_s * (math.pi / 180)) / 2)
     )
-    dx = (x_e - x_s) * (np.pi / 180)
-    dy = (y_e - y_s) * (np.pi / 180)
+    dx = (x_e - x_s) * (math.pi / 180)
+    dy = (y_e - y_s) * (math.pi / 180)
     if dy_corrected == 0 and dy == 0:
-        q = np.cos(y_e * (np.pi / 180))
+        q = math.cos(y_e * (math.pi / 180))
     else:
         q = dy / dy_corrected
 
-    distance = np.sqrt(dy**2 + (q**2) * (dx**2)) * r
+    distance = math.sqrt(dy**2 + (q**2) * (dx**2)) * r
 
     return distance
 
@@ -99,26 +102,26 @@ def rhumb_traveltime_in_cell(cellbox, cp, sp, s, u, v):
     ):
         x = (cp[0] - sp[0]) * 111.386 * 1000.0
         y = (cp[1] - sp[1]) * 111.321 * 1000.0
-        λ = sp[1] * (np.pi / 180)
-        θ = cp[1] * (np.pi / 180)
+        λ = sp[1] * (math.pi / 180)
+        θ = cp[1] * (math.pi / 180)
         C1 = s**2 - u**2 - v**2
-        # z = x * np.cos(θ)
-        r1 = np.cos(λ) / np.cos(θ)
-        d1 = np.sqrt(x**2 + (r1 * y) ** 2)
+        # z = x * math.cos(θ)
+        r1 = math.cos(λ) / math.cos(θ)
+        d1 = math.sqrt(x**2 + (r1 * y) ** 2)
         D1 = x * u + r1 * v * y
     # If horizontal case
     else:
         x = (cp[0] - sp[0]) * 111.386 * 1000.0
         y = (cp[1] - sp[1]) * 111.321 * 1000.0
-        λ = sp[1] * (np.pi / 180)
+        λ = sp[1] * (math.pi / 180)
         θ = y / (2 * 6371 * 1000) + λ
         C1 = s**2 - u**2 - v**2
-        z = x * np.cos(θ)
-        # r1 = np.cos(λ) / np.cos(θ)
+        z = x * math.cos(θ)
+        # r1 = math.cos(λ) / math.cos(θ)
         D1 = z * u + y * v
-        d1 = np.sqrt(z**2 + y**2)
+        d1 = math.sqrt(z**2 + y**2)
 
-    X1 = np.sqrt(D1**2 + C1 * (d1**2))
+    X1 = math.sqrt(D1**2 + C1 * (d1**2))
     tt = (X1 - D1) / C1
     return tt
 
@@ -525,19 +528,19 @@ class Smoothing:
                 ϕ_r = ρ
 
             θ = y / (2 * R) + ϕ_l  # (y/R + λ_s)
-            zl = x * np.cos(θ)
+            zl = x * math.cos(θ)
             ψ = (Y - y) / (2 * R) + ϕ_r  # ((Y-y)/R + φ_r)
-            zr = a * np.cos(ψ)
+            zr = a * math.cos(ψ)
 
             C1 = speed_s**2 - u1**2 - v1**2
             C2 = speed_e**2 - u2**2 - v2**2
             D1 = zl * u1 + y * v1
             D2 = zr * u2 + (Y - y) * v2
-            X1 = np.sqrt(D1**2 + C1 * (zl**2 + y**2))
-            X2 = np.sqrt(D2**2 + C2 * (zr**2 + (Y - y) ** 2))
+            X1 = math.sqrt(D1**2 + C1 * (zl**2 + y**2))
+            X2 = math.sqrt(D2**2 + C2 * (zr**2 + (Y - y) ** 2))
 
-            dzr = -a * np.sin(ψ) / (2 * R)  # -zr*np.sin(ψ)/R
-            dzl = -x * np.sin(θ) / (2 * R)  # -zl*np.sin(θ)/R
+            dzr = -a * math.sin(ψ) / (2 * R)  # -zr*math.sin(ψ)/R
+            dzl = -x * math.sin(θ) / (2 * R)  # -zl*math.sin(θ)/R
 
             dD1 = dzl * u1 + v1
             dD2 = dzr * u2 - v2
@@ -588,8 +591,8 @@ class Smoothing:
         else:
             sgn = -1
 
-        λ_s = Sp[1] * (np.pi / 180)
-        φ_r = Np[1] * (np.pi / 180)
+        λ_s = Sp[1] * (math.pi / 180)
+        φ_r = Np[1] * (math.pi / 180)
 
         x = dist_around_globe(Cp[0], Sp[0]) * 111.321 * 1000.0
         a = dist_around_globe(Np[0], Cp[0]) * 111.321 * 1000.0
@@ -723,22 +726,22 @@ class Smoothing:
                 X2 (float) - Characteristic X distance in end cell
 
             """
-            λ = λ * (np.pi / 180)
-            ψ = ψ * (np.pi / 180)
-            θ = θ * (np.pi / 180)
-            # r1  = np.cos(λ)/np.cos(θ)
-            r1 = np.cos((θ + 3 * λ) / 4) / np.cos(θ)
-            # r2  = np.cos(ψ)/np.cos(θ)
-            r2 = np.cos((θ + 3 * ψ) / 4) / np.cos(θ)
+            λ = λ * (math.pi / 180)
+            ψ = ψ * (math.pi / 180)
+            θ = θ * (math.pi / 180)
+            # r1  = math.cos(λ)/math.cos(θ)
+            r1 = math.cos((θ + 3 * λ) / 4) / math.cos(θ)
+            # r2  = math.cos(ψ)/math.cos(θ)
+            r2 = math.cos((θ + 3 * ψ) / 4) / math.cos(θ)
 
-            d1 = np.sqrt(x**2 + (r1 * y) ** 2)
-            d2 = np.sqrt(a**2 + (r2 * (Y - y)) ** 2)
+            d1 = math.sqrt(x**2 + (r1 * y) ** 2)
+            d2 = math.sqrt(a**2 + (r2 * (Y - y)) ** 2)
             C1 = speed_s**2 - u1**2 - v1**2
             C2 = speed_e**2 - u2**2 - v2**2
             D1 = x * u1 + r1 * v1 * y
             D2 = a * u2 + r2 * v2 * (Y - y)
-            X1 = np.sqrt(D1**2 + C1 * (d1**2))
-            X2 = np.sqrt(D2**2 + C2 * (d2**2))
+            X1 = math.sqrt(D1**2 + C1 * (d1**2))
+            X2 = math.sqrt(D2**2 + C2 * (d2**2))
 
             dX1 = (r1 * (D1 * v1 + r1 * C1 * y)) / X1
             dX2 = (-r2 * (D2 * v2 + r2 * C2 * (Y - y))) / X2
@@ -782,7 +785,7 @@ class Smoothing:
 
         x = sgn * (Cp[1] - Sp[1]) * 111.386 * 1000.0
         a = -sgn * (Np[1] - Cp[1]) * 111.386 * 1000.0
-        Y = sgn * (Np[0] - Sp[0]) * 111.321 * 1000 * np.cos(Cp[1] * (np.pi / 180))
+        Y = sgn * (Np[0] - Sp[0]) * 111.321 * 1000 * math.cos(Cp[1] * (math.pi / 180))
         Su = -sgn * cell_s_v
         Sv = sgn * cell_s_u
         Nu = -sgn * cell_e_v
@@ -793,7 +796,7 @@ class Smoothing:
             _F, y0, x, a, Y, Su, Sv, Nu, Nv, speed_s, speed_e, Rd, λ, θ, ψ
         )
 
-        Cp = (Sp[0] + sgn * y / (111.321 * 1000 * np.cos(Cp[1] * (np.pi / 180))), Cp[1])
+        Cp = (Sp[0] + sgn * y / (111.321 * 1000 * math.cos(Cp[1] * (math.pi / 180))), Cp[1])
 
         return Cp
 
@@ -869,8 +872,8 @@ class Smoothing:
             emax = cell_b["cy"] + cell_b["dcy"]
 
             # Defining the global min and max
-            vmin = np.max([smin, emin])
-            vmax = np.min([smax, emax])
+            vmin = max(smin, emin)
+            vmax = min(smax, emax)
 
             # Point lies on the boundary connecting up the
             # two adjacent cell pairs, the start and end cell.
@@ -915,8 +918,8 @@ class Smoothing:
             emax = cell_b["cx"] + cell_b["dcx"]
 
             # Defining the global min and max
-            vmin = np.max([smin, emin])
-            vmax = np.min([smax, emax])
+            vmin = max(smin, emin)
+            vmax = min(smax, emax)
 
             # Point lies on the boundary connecting up the
             # two adjacent cell pairs, the start and end cell.
@@ -1230,10 +1233,10 @@ class Smoothing:
             emax = cell_b["cy"] + cell_b["dcy"]
 
             # Defining the global min and max
-            vmin = np.max([smin, emin])
-            vmax = np.min([smax, emax])
+            vmin = max(smin, emin)
+            vmax = min(smax, emax)
 
-            x = (x[0], np.clip(x[1], vmin, vmax))
+            x = (x[0], min(max(x[1], vmin), vmax))
 
         elif abs(case) == 4:
             # Defining the min and max of the start and end cells
@@ -1243,10 +1246,10 @@ class Smoothing:
             emax = cell_b["cx"] + cell_b["dcx"]
 
             # Defining the global min and max
-            vmin = np.max([smin, emin])
-            vmax = np.min([smax, emax])
+            vmin = max(smin, emin)
+            vmax = min(smax, emax)
 
-            x = (np.clip(x[0], vmin, vmax), x[1])
+            x = (min(max(x[0], vmin), vmax), x[1])
 
         return x
 
@@ -1680,8 +1683,8 @@ class Smoothing:
                 )
                 if (
                     midpoint_prime is None
-                    or np.isnan(midpoint_prime[0])
-                    or np.isnan(midpoint_prime[1])
+                    or math.isnan(midpoint_prime[0])
+                    or math.isnan(midpoint_prime[1])
                 ):
                     raise RouteSmoothingError(
                         "Newton call failed to converge or recover"


### PR DESCRIPTION
Replacing where possible numpy scalar math with `math` module. Some genuine array operations were retained where needed.

Benchmark vs the `tz/heapq` branch:

| Test | Pre-swap (ms) | Post-swap (ms) | Speedup |
|---|---:|---:|---:|
| dijkstra[small] | 12.676 | 10.862 | 1.167x |
| dijkstra[medium] | 147.792 | 87.232 | 1.694x |
| dijkstra[large] | 906.899 | 628.749 | 1.442x |
| dijkstra[complex] | 1236.648 | 963.282 | 1.284x |
| bidirectional_dijkstra[small] | 13.350 | 10.591 | 1.260x |
| bidirectional_dijkstra[medium] | 149.380 | 90.048 | 1.659x |
| bidirectional_dijkstra[large] | 968.707 | 684.247 | 1.416x |
| bidirectional_dijkstra[complex] | 1185.495 | 925.632 | 1.281x |
| smoothed[small] | 458.457 | 282.998 | 1.620x |
| smoothed[medium] | 6807.265 | 6115.418 | 1.113x |
| smoothed[large] | 14091.431 | 7072.044 | 1.993x |